### PR TITLE
Fix wording of ISC License.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Copyright (c) 2016-2019 Ataraxia Linux <ataraxialinux@protonmail.ch>
 
-Permission to use, copy, modify, and distribute this software for any
+Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
 copyright notice and this permission notice appear in all copies.
 


### PR DESCRIPTION
Added `and/or` to LICENSE file as stated by the [OSI](https://opensource.org/licenses/ISC).

`and/or` was added in 2007 to avoid [confusion](https://groups.google.com/forum/#!msg/comp.protocols.dns.bind/D8VLXloVfxc/4yweyAjRCecJ).