### PR TITLE
Remove deprecated --enable-widec

### DIFF
--- a/packages/libedit/KagamiBuild
+++ b/packages/libedit/KagamiBuild
@@ -14,8 +14,7 @@ source=("http://thrysoee.dk/editline/$name-${_pkgver}.tar.gz")
 build() {
 	cd "$SRC"/$name-${_pkgver}
 	./configure $BUILDFLAGS \
-		--prefix=/usr \
-		--enable-widec
+		--prefix=/usr
 	make
 	make DESTDIR="$PKG" install
 


### PR DESCRIPTION
According to libedit's `./configure --help`:
```
...
  --enable-widec          deprecated, wide-character/UTF-8 is always enabled
...
```

Also after running `./configure`:
```
...
configure: WARNING: --enable-widec is deprecated, wide-character/UTF-8 is always enabled
...
```