### PR TITLE
Remove flags enabled by default from binutils

### DIFF
--- a/packages/binutils/KagamiBuild
+++ b/packages/binutils/KagamiBuild
@@ -32,19 +32,14 @@ build() {
 		--with-bugurl="https://github.com/ataraxialinux/ataraxia/issues" \
 		--with-pic \
 		--with-system-zlib \
-		--enable-64-bit-bfd \
 		--enable-deterministic-archives \
 		--enable-gold \
 		--enable-ld=default \
-		--enable-lto \
-		--enable-plugins \
 		--enable-relro \
-		--enable-shared \
 		--enable-threads \
 		--disable-compressed-debug-sections \
 		--disable-multilib \
-		--disable-nls \
-		--disable-werror
+		--disable-nls
 	make MAKEINFO="true" configure-host
 	make MAKEINFO="true" tooldir=/usr
 	make MAKEINFO="true" tooldir=/usr DESTDIR="$PKG" install


### PR DESCRIPTION
Removed unnecessary flags that are automatically enabled by system binutils:

`--enable-lto` is enabled by default

`--enable-plugins` is on by default as it's needed for largefile? (it's also needed when building gold)

`--enable-64-bit-bfd` is enabled by default for 64 bit targets, as it's only intended for enabling 64-bit support on 32-bit (and smaller) hosts

`--enable-64-bit-archive` is enabled by default for 64 bit targets as it's only intended for enabling 64-bit support on 32-bit (and smaller) hosts

`--disable-werror` is on by default so no need to add it