### PR TITLE
Remove flags from host gcc static

### DIFF
--- a/toolchain/host-gcc-static/KagamiBuild
+++ b/toolchain/host-gcc-static/KagamiBuild
@@ -124,18 +124,13 @@ build() {
 		--with-system-zlib \
 		--with-newlib \
 		--without-headers \
-		--enable-checking=release \
 		--enable-clocale=generic \
 		--enable-default-pie \
 		--enable-default-ssp \
 		--enable-languages=c \
 		--enable-linker-build-id \
-		--enable-lto \
-		--enable-plugins \
 		--disable-decimal-float \
-		--disable-gnu-indirect-function \
 		--disable-libatomic \
-		--disable-libcilkrts \
 		--disable-libgomp \
 		--disable-libitm \
 		--disable-libquadmath \
@@ -147,7 +142,7 @@ build() {
 		--disable-nls \
 		--disable-shared \
 		--disable-symvers \
-		--disable-threads \
+		--enable-threads=single \
 		--disable-werror
 	make all-gcc all-target-libgcc
 	make -j1 install-gcc install-target-libgcc


### PR DESCRIPTION
Removed unnecessary flags:

* `--enable-checking=release` is enabled by default when GCC is being built from a release tarball (check <https://gcc.gnu.org/install/configure.html>)
* `--enable-lto` is enabled by default (check GCC configure script)
* `--enable-plugins` is enabled by default (check GCC configure script)
*`--disable-gnu-indirect-function` is enabled by default since we're using musl (check <https://gcc.gnu.org/install/configure.html>)
* `--disable-libcilkrts`: libcilkrts has been removed from GCC since 2017
* `--disable-threads` is just an alias for `--enable-threads=single`