### PR TITLE
It's plugin not plugins

### DIFF
--- a/packages/gcc/KagamiBuild
+++ b/packages/gcc/KagamiBuild
@@ -117,7 +117,7 @@ build() {
 		--enable-libstdcxx-time \
 		--enable-linker-build-id \
 		--enable-lto \
-		--enable-plugins \
+		--enable-plugin \
 		--enable-shared \
 		--enable-threads=posix \
 		--enable-tls \

--- a/toolchain/host-gcc-static/KagamiBuild
+++ b/toolchain/host-gcc-static/KagamiBuild
@@ -118,7 +118,7 @@ build() {
 		--enable-languages=c \
 		--enable-linker-build-id \
 		--enable-lto \
-		--enable-plugins \
+		--enable-plugin \
 		--disable-decimal-float \
 		--disable-libatomic \
 		--disable-libgomp \

--- a/toolchain/host-gcc/KagamiBuild
+++ b/toolchain/host-gcc/KagamiBuild
@@ -124,7 +124,7 @@ build() {
 		--enable-libstdcxx-time \
 		--enable-linker-build-id \
 		--enable-lto \
-		--enable-plugins \
+		--enable-plugin \
 		--enable-shared \
 		--enable-threads=posix \
 		--enable-tls \


### PR DESCRIPTION
Plugins are automatically enabled by GCC. That said the correct command to enable plugin support is by specifying `--enable-plugin` and not `--enable-plugins` (that's for binutils).