### PR TITLE
Remove prefix flag from iproute2 configure

### DIFF
--- a/packages/iproute2/KagamiBuild
+++ b/packages/iproute2/KagamiBuild
@@ -29,8 +29,7 @@ build() {
 		-e 's:-Werror::' Makefile
 	sed -e 's/^check_elf$/echo "no"/' -i configure
 
-	./configure $BUILDFLAGS \
-		--prefix=/usr
+	./configure $BUILDFLAGS
 	make
 	make DESTDIR="$PKG" SBINDIR="/usr/bin" install
 }


### PR DESCRIPTION
I don't think `iproute2`'s configure script accepts `--prefix` flag.