### PR TITLE
Fix pkgconf environment variables

### DIFF
--- a/build
+++ b/build
@@ -66,7 +66,7 @@ if [ "$USE_TARGET" = "1" ]; then
 		export BUILDFLAGS="--build=$XHOST --host=$XTARGET"
 		export TOOLFLAGS="--build=$XHOST --host=$XTARGET --target=$XTARGET"
 		export PERLFLAGS="--target=$XTARGET"
-		export PKG_CONFIG_PATH="$ROOTFS/usr/lib/pkgconfig:$ROOTFS/usr/share/pkgconfig"
+		export PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/share/pkgconfig"
 		export PKG_CONFIG_SYSROOT_DIR="$ROOTFS"
 		export HOSTCC="$HOSTCC"
 		export HOSTCXX="$HOSTCXX"


### PR DESCRIPTION
According to `pkgconf`'s man page:
```
PKG_CONFIG_SYSROOT_DIR
‘sysroot’ directory, will be prepended to every path defined in PKG_CONFIG_PATH. Useful for cross compilation.
```