### PR TITLE
No need to specify sysroot

### DIFF
--- a/toolchain/host-pkgconf/KagamiBuild
+++ b/toolchain/host-pkgconf/KagamiBuild
@@ -9,7 +9,7 @@ build() {
 	LDFLAGS="-static" \
 	./configure \
 		--prefix="$TOOLS" \
-		--with-sysroot="$ROOTFS" \
+		--with-sysroot \
 		--with-pkg-config-dir="/usr/lib/pkgconfig:/usr/share/pkgconfig" \
 		--with-system-libdir="$ROOTFS/usr/lib" \
 		--with-system-includedir="$ROOTFS/usr/include"


### PR DESCRIPTION
Using `--with-sysroot` alone is enough to let pkgconf's configure script figure out the sysroot from the compiler, and since you've already passed `--with-sysroot="$ROOTFS"` to the compiler (to test it, run `$CC --print-sysroot` and see if you get `$ROOTFS`), there's no need to specify sysroot here.

From pkgconf's configure scripts
```Md
  --with-sysroot[=DIR]    Search for dependent libraries within DIR (or the compiler's sysroot if not specified).
```