### PR TITLE
It's actually --with-long-double-64

### DIFF
--- a/packages/gcc/KagamiBuild
+++ b/packages/gcc/KagamiBuild
@@ -38,7 +38,7 @@ build() {
 				export GCCOPTS="--with-abi=elfv2 --enable-secureplt --enable-targets=powerpc-linux --disable-decimal-float --disable-libquadmath"
 				;;
 			ppc)
-				export GCCOPTS="--with-long-double=64 --enable-secureplt --disable-decimal-float"
+				export GCCOPTS="--with-long-double-64 --enable-secureplt --disable-decimal-float"
 				;;
 			s390x)
 				export GCCOPTS="--with-arch=z196 --with-tune=z14 --with-zarch --with-long-double-128 --enable-decimal-float"

--- a/toolchain/host-gcc-static/KagamiBuild
+++ b/toolchain/host-gcc-static/KagamiBuild
@@ -37,7 +37,7 @@ build() {
 				export GCCOPTS="--with-abi=elfv2 --enable-secureplt --enable-targets=powerpc-linux --disable-decimal-float --disable-libquadmath"
 				;;
 			ppc)
-				export GCCOPTS="--with-long-double=64 --enable-secureplt --disable-decimal-float"
+				export GCCOPTS="--with-long-double-64 --enable-secureplt --disable-decimal-float"
 				;;
 			s390x)
 				export GCCOPTS="--with-arch=z196 --with-tune=z14 --with-zarch --with-long-double-128 --enable-decimal-float"

--- a/toolchain/host-gcc/KagamiBuild
+++ b/toolchain/host-gcc/KagamiBuild
@@ -37,7 +37,7 @@ build() {
 				export GCCOPTS="--with-abi=elfv2 --enable-secureplt --enable-targets=powerpc-linux --disable-decimal-float --disable-libquadmath"
 				;;
 			ppc)
-				export GCCOPTS="--with-long-double=64 --enable-secureplt --disable-decimal-float"
+				export GCCOPTS="--with-long-double-64 --enable-secureplt --disable-decimal-float"
 				;;
 			s390x)
 				export GCCOPTS="--with-arch=z196 --with-tune=z14 --with-zarch --with-long-double-128 --enable-decimal-float"


### PR DESCRIPTION
According to GCC's configuration manual and to the musl wiki, it's actually `--with-long-double-64` and not `--with-long-double=64`.

From GCC's configuration manual:

> If you use the --with-long-double-64 configuration option, the --with-long-double-format=ibm and --with-long-double-format=ieee options are ignored.

From [the FAQ section in musl wiki](https://wiki.musl-libc.org/faq.html):
> If that crashes, despite having PPC_GOT entries, you are affected. Further, you should build gcc with the option --with-long-double-64 --enable-secureplt.