### PR TITLE
build: replace which with command -v

### DIFF
--- a/build
+++ b/build
@@ -160,7 +160,7 @@ setup_environment() {
 	export PATH="$UTILS:$TOOLS/bin:$PATH"
 	export HOSTCC="gcc"
 	export HOSTCXX="g++"
-	export ORIGMAKE="$(which make)"
+	export ORIGMAKE="$(command -v make)"
 
 	if [ -z "$JOBS" ]; then
 		export JOBS="$(expr $(nproc) + 1)"


### PR DESCRIPTION
Replace `which` with `command -v` in build; rationale at https://github.com/koalaman/shellcheck/wiki/SC2230