### PR TITLE
Add which to RPM-distro dependency list

### DIFF
--- a/docs/bootstrapping.md
+++ b/docs/bootstrapping.md
@@ -7,7 +7,7 @@ apt-get install build-essential m4 bison flex texinfo python3 python perl libtoo
 #### Fedora/RHEL/CentOS
 ```
 dnf groupinstall "Development Tools" "C Development Tools and Libraries"
-dnf install gcc gcc-g++ libstdc++-static glibc-static mtools libisoburn python3 pigz libarchive curl bsdtar xorriso autoconf automake libtool freetype-devel zlib-devel xz-devel libzstd-devel libarchive-devel elfutils-libelf-devel openssl-devel libdb-devel popt-devel file file-devel libacl-devel libcap-devel gettext-devel gcc-plugin-devel gmp-devel mpfr-devel libmpc-devel readline-devel
+dnf install gcc gcc-g++ libstdc++-static glibc-static mtools libisoburn python3 pigz libarchive curl bsdtar xorriso autoconf automake libtool freetype-devel zlib-devel xz-devel libzstd-devel libarchive-devel elfutils-libelf-devel openssl-devel libdb-devel popt-devel file file-devel libacl-devel libcap-devel gettext-devel gcc-plugin-devel gmp-devel mpfr-devel libmpc-devel readline-devel which
 ln -sf python3 /usr/bin/python
 ```
 #### Arch Linux (and derivatives):


### PR DESCRIPTION
Adds `which`, which isn't installed by default in all cases.