### PR TITLE
packages: Add micro

### DIFF
--- a/packages/micro/KagamiBuild
+++ b/packages/micro/KagamiBuild
@@ -1,0 +1,16 @@
+# Description: A modern and intuitive terminal-based text editor
+# URL:         https://micro-editor.github.io/
+# Maintainer:  Miko, mikoxyzzz at gmail dot com 
+# Depends on:  go
+# Section:     editors
+
+name=micro
+version=2.0.8
+release=1
+source=("https://github.com/zyedidia/micro/archive/refs/tags/v$version.tar.gz")
+
+build() {
+	cd "$SRC"/$name-$version
+	make build
+	mv micro /usr/bin
+}


### PR DESCRIPTION
Note: Micro has a soft dependency on xclip/xsel for clipboard support in X. Since it's not a hard dependency, I've decided to not add it as a build dependency.
Note 2: I haven't actually tested this yet; should work just fine, though ^^;