### PR TITLE
packages: Add doas

### DIFF
--- a/packages/doas/KagamiBuild
+++ b/packages/doas/KagamiBuild
@@ -12,7 +12,7 @@ backup=('etc/doas.conf')
 source=("https://github.com/Duncaen/$alt_name/archive/refs/tags/v$version.tar.gz::archive=$name-$version.tar.gz")
 
 build() {
-        cd "$SRC"/$alt_name-$version
+	cd "$SRC"/$alt_name-$version
 	./configure \
 		--prefix=/usr \
 		--sysconfdir=/etc \

--- a/packages/doas/KagamiBuild
+++ b/packages/doas/KagamiBuild
@@ -1,0 +1,26 @@
+# Description: A portable fork of the OpenBSD `doas` command (alt sudo) (unofficial port from OpenBSD)
+# URL:         https://github.com/Duncaen/OpenDoas
+# Maintainer:  owl4ce, findarr at pm dot me
+# Depends on:  pam
+# Section:     admin
+
+name=doas
+alt_name=OpenDoas
+version=6.8.1
+release=1
+backup=('etc/doas.conf')
+source=("https://github.com/Duncaen/$alt_name/archive/refs/tags/v$version.tar.gz::archive=$name-$version.tar.gz")
+
+build() {
+        cd "$SRC"/$alt_name-$version
+	./configure \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--with-pam \
+		--with-timestamp
+	make
+	make DESTDIR="$PKG" install
+	
+	# Install example configuration
+	install -m644 -D "$STUFF"/doas/doas.conf "$PKG"/etc/doas.conf
+}

--- a/stuff/doas/doas.conf
+++ b/stuff/doas/doas.conf
@@ -1,0 +1,2 @@
+permit persist keepenv :wheel
+permit nopass keepenv root


### PR DESCRIPTION
A portable fork of the OpenBSD `doas` command (alt sudo) (unofficial port from OpenBSD)

![2021-04-01-224216_1920x1080_scrot](https://user-images.githubusercontent.com/53987136/113320619-e557f600-933c-11eb-99d2-1ac10d3c34c1.png)
