### PR TITLE
libc: use <stddef.h> instead of <sys/types.h>

### DIFF
--- a/stuff/tzdb/strlcat.c
+++ b/stuff/tzdb/strlcat.c
@@ -16,7 +16,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/types.h>
+#include <stddef.h>
 #include <string.h>
 #include <bsd.h>
 

--- a/stuff/tzdb/strlcpy.c
+++ b/stuff/tzdb/strlcpy.c
@@ -16,7 +16,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/types.h>
+#include <stddef.h>
 #include <string.h>
 #include <bsd.h>
 


### PR DESCRIPTION
stddef.h has advantages over sys/types.h namely that it is part of the
C standard as well as the fact that it contains only the definitions
required by these functions and therefore doesn't litter the typedef
space.