### PR TITLE
musl already defines __STDC_ISO_10646__ as 201206L

### DIFF
--- a/packages/libedit/KagamiBuild
+++ b/packages/libedit/KagamiBuild
@@ -13,7 +13,7 @@ build() {
 	local i
 
 	cd "$SRC"/$name-${version/+/-}
-	CFLAGS="-D__STDC_ISO_10646__=201103L $CFLAGS" \
+	CFLAGS="-D__STDC_ISO_10646__ $CFLAGS" \
 	./configure $BUILDFLAGS \
 		--prefix=/usr
 	make


### PR DESCRIPTION
As of 1.1.15, musl already defines `__STDC_ISO_10646__` as `201206L`.